### PR TITLE
Release 1.0.1

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "NMFMerge"
 uuid = "9cc52eda-dfaf-4e21-aae3-9f26bed153a3"
 authors = ["youdongguo <1010705897@qq.com> and contributors"]
-version = "1.0.2"
+version = "1.0.1"
 
 [deps]
 DataStructures = "864edb3b-99cc-5e75-8d2d-829cb0a9cfe8"


### PR DESCRIPTION
Version 1.0.2 never got released because version 1.0.1 never did, either; the registry complained that we skipped 1.0.1. https://github.com/JuliaRegistries/General/pull/124118

This sets the version number back to 1.0.1 so it can be released.