### PR TITLE
Fix merging of W=0 components

### DIFF
--- a/src/NMFMerge.jl
+++ b/src/NMFMerge.jl
@@ -139,11 +139,16 @@ end
 
 function solve_remix(S, T, id1, id2)
     τ, δ, c, h1h1, h1h2, h2h2 = build_tr_det(S, T, id1, id2)
-    if h1h1 == 0
+    if iszero(h1h1)
         return c, zero(c), (zero(c), one(c))
     end
-    if h2h2 == 0
+    if iszero(h2h2)
         return c, zero(c), (one(c), zero(c))
+    end
+    if iszero(c)
+        # Check whether W1 or W2 is zero
+        iszero(sum(abs2, S[id1])) && return c, zero(h1h1), (zero(c), one(c))
+        iszero(sum(abs2, S[id2])) && return c, zero(h2h2), (one(c), zero(c))
     end
     b = sqrt(τ^2/4-δ)
     λ_max = τ/2+b

--- a/src/NMFMerge.jl
+++ b/src/NMFMerge.jl
@@ -98,7 +98,8 @@ function colmerge2to1pq(S::AbstractArray, T::AbstractArray, n::Integer)
         [T[i, :] for i in axes(T, 1)]
     end
     for s in S
-        abs(norm(s)-1)<1e-12 || throw(ArgumentError("W columns must be normalized"))
+        snorm = norm(s)
+        (abs(snorm-1)<1e-12 && !iszero(snorm)) || throw(ArgumentError("W columns must be normalized"))
     end
     Nt = length(S)
     Nt >= 2 || throw(ArgumentError("Cannot do 2 to 1 merge: Matrix size smaller than 2"))

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -32,7 +32,7 @@ H_GT = [6 10 8 2 0 1 2 10;
      4 9 10 7 7 0 0 0
     ]
 
-@testset "test top wrapper" begin        
+@testset "test top wrapper" begin
     W = W_GT[:, 3:4]
     H = H_GT[3:4, :]
     X = W*H
@@ -67,7 +67,7 @@ H_GT = [6 10 8 2 0 1 2 10;
     result_2 = nmfmerge(X, 10 => 8; alg=:cd)
     @test sum(abs2, result_1.W - result_2.W) <= 1e-12
     @test sum(abs2, result_1.H - result_2.H) <= 1e-12
-    
+
 end
 
 @testset "merge coefficients" begin
@@ -101,7 +101,7 @@ end
         @test norm(u[1].*W_v[1].+u[2].*W_v[2]) ≈ 1
         @test norm(Q1*u - maximum(F.values)*Q2*u) <= 1e-10
         @test norm(Q1*u - λ_max*Q2*u) <= 1e-10
-        
+
         W12, H12, loss = NMFMerge.mergepair(W_v, H_v, 1, 2)
         Err(Hm) = sum(abs2, W12 * Hm' - W * H)
         @test norm(ForwardDiff.gradient(Err, H12)) <= 1e-10
@@ -121,7 +121,7 @@ end
     imgnf = NMF.solve!(NMF.CoordinateDescent{Float64}(), img, W0, H0)
     W1, H1 = imgnf.W, imgnf.H
     W1n, H1n = colnormalize(W1, H1)
-    [@test abs(norm(W1n[:,j], 2)-1) <= 1e-12 for j in axes(W1n, 2)] 
+    [@test abs(norm(W1n[:,j], 2)-1) <= 1e-12 for j in axes(W1n, 2)]
 
     W2 = [W1n[:, j] for j in axes(W1n, 2)];
     H2 = [H1n[i, :] for i in axes(H1n, 1)];
@@ -140,7 +140,7 @@ end
     b = sqrt(τ^2/4-δ)
     λ_max = τ/2+b
     λ_min = δ/λ_max
-    
+
     @test abs(λ_max - maximum(F.values))<=1e-12
     @test abs(λ_min - minimum(F.values))<=1e-10
 
@@ -169,7 +169,7 @@ end
     N1b = randn(length(S1)); N1b = N1b / norm(N1b) * coef
     T2 = zero(T1)
     T2[15] = 0.25 * sqrt(min(sum(abs2, N1a) * sum(abs2, T1a), sum(abs2, N1b) * sum(abs2, T1b)))
-    
+
     W, H = [S1 S1 S2], [T1a'; T1b'; T2']
     W0, H0 = [S1 S2], [T1'; T2']
     Wn, Hn = colnormalize(W, H)
@@ -187,4 +187,15 @@ end
     @test pop!(copy(mergids)) == Ids[i]
     @test pop!(mergids) == (1,2)
 
+end
+
+@testset "Merge zero component" begin
+    wrand = rand(5)
+    wrand ./= norm(wrand)
+    Ws = [wrand, zeros(5)]
+    Hs = [rand(10), rand(10)]
+    W12, H12, loss = NMFMerge.mergepair(Ws, Hs, 1, 2)
+    @test W12 ≈ wrand
+    @test H12 ≈ Hs[1]
+    @test iszero(loss)
 end


### PR DESCRIPTION
We implicitly assume that the spatial components are normalized.
However, if one of them is zero, it is not possible to normalize it.
Check for this case and handle it separately.