### PR TITLE
Return per-merge error from colmerge2to1pq

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ Suppose you have the NMF solution ``W`` and ``H`` with ``r`` componenents, **col
 This function merges components in ``W`` and ``H`` (columns in ``W`` and rows in ``H``) from original number of components to ``n`` components (``n``columns and rows left in ``W`` and ``H`` respectively).
 
 To use this function:
-`Wmerge, Hmerge, mergeseq = colmerge2to1pq(W, H, n)`, where ``Wmerge`` and ``Hmerge`` are the merged results with ``n`` components. ``mergeseq`` is the sequence of merge pair ids ``(id1, id2)``, which is the components id of single merge.
+`Wmerge, Hmerge, mergeseq = colmerge2to1pq(W, H, n)`, where ``Wmerge`` and ``Hmerge`` are the merged results with ``n`` components. ``mergeseq`` is the sequence of merges as ``(id1, id2, err)`` tuples, where ``id1`` and ``id2`` are the merged component ids and ``err`` is the reconstruction error incurred by that merge. Merging all the way down (``n=1``) and inspecting the ``err`` values lets you locate a "knee" at which to stop, then replay the corresponding prefix of ``mergeseq`` with ``mergecolumns``.
 
 -----
 

--- a/src/NMFMerge.jl
+++ b/src/NMFMerge.jl
@@ -111,11 +111,16 @@ Outputs:
 
 `Wmerge` and `Hmerge` are the merged results with `n` components.
 
-`mergeseq` is the sequence of merge pair ids (id1, id2). Values larger than the
-number of columns in `W` indicate the output of previous merge steps.
+`mergeseq` is the sequence of merges as `(id1, id2, err)` tuples, in the order
+they were performed. `id1` and `id2` are the ids of the merged components and
+`err` is the reconstruction error (the merge penalty) incurred by that merge.
+Ids larger than the number of columns in `W` refer to components produced by
+earlier merges. The accumulating `err` values let a caller merge all the way
+down (`n == 1`) and locate a "knee" at which to stop, then replay the
+corresponding prefix of `mergeseq` with [`mergecolumns`](@ref).
 """
 function colmerge2to1pq(queuepenalty, S::AbstractArray, T::AbstractArray, n::Integer)
-    mrgseq = Tuple{Int, Int}[]
+    mrgseq = Tuple{Int, Int, Float64}[]
     S = let S = S    # julia #15276
         [S[:, j] for j in axes(S, 2)]
     end
@@ -139,8 +144,8 @@ function colmerge2to1pq(queuepenalty, S::AbstractArray, T::AbstractArray, n::Int
         if isempty(S[id0])||isempty(S[id1])
             continue
         end
-        push!(mrgseq, (id0, id1))
-        S, T, id01, _ = mergecol2to1!(S, T, id0, id1);
+        S, T, id01, loss = mergecol2to1!(S, T, id0, id1)
+        push!(mrgseq, (id0, id1, loss))
         pqupdate2to1!(queuepenalty, pq, S, T, id01, 1:id01-1);
         m -= 1
     end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -199,8 +199,8 @@ end
     loss3 = NMFMerge.mergepair(Wn1, Hn1, Ids[3][1], Ids[3][2])[end]
     i = findmin([loss1, loss2, loss3])[2]
 
-    @test pop!(copy(mergids)) == Ids[i]
-    @test pop!(mergids) == (1,2)
+    @test pop!(copy(mergids))[1:2] == Ids[i]
+    @test pop!(mergids)[1:2] == (1,2)
 
 end
 
@@ -241,7 +241,36 @@ end
     idpair_loss = sort(idpair_loss, by=x->x[2])
     merge_sequence = colmerge2to1pq(Wsn, Hsn, 1)[end]
     merge_sequence_custom = colmerge2to1pq(mergepenalty_custom, Wsn, Hsn, 1)[end]
-    @test merge_sequence[1] == idpair_loss[1][1]
-    @test merge_sequence_custom[1] == idpair_loss[3][1]
+    @test merge_sequence[1][1:2] == idpair_loss[1][1]
+    @test merge_sequence_custom[1][1:2] == idpair_loss[3][1]
 
+end
+
+@testset "Knee-finding workflow" begin
+    Wn, Hn = colnormalize(float.(W_GT), float.(H_GT))
+    ncols = size(Wn, 2)
+
+    # Merge all the way down to a single component, recording every merge error.
+    Wfull, Hfull, schedule = colmerge2to1pq(Wn, Hn, 1)
+    @test size(Wfull, 2) == 1
+    @test length(schedule) == ncols - 1
+    errs = [s[3] for s in schedule]
+    @test all(>=(0), errs)
+
+    # Replaying the full schedule reproduces the final factors and the same
+    # per-merge errors that colmerge2to1pq reported.
+    Wr, Hr, _, Err = mergecolumns(Wn, Hn, schedule)
+    @test Err ≈ errs
+    @test Wr ≈ Wfull
+    @test Hr ≈ Hfull
+
+    # Knee: stopping the merge at rank k equals replaying the first ncols-k
+    # merges of the full schedule.
+    for k in 1:ncols-1
+        Wk, Hk, _ = colmerge2to1pq(Wn, Hn, k)
+        Wkr, Hkr, _, _ = mergecolumns(Wn, Hn, schedule[1:ncols-k])
+        @test size(Wkr, 2) == k
+        @test Wkr ≈ Wk
+        @test Hkr ≈ Hk
+    end
 end


### PR DESCRIPTION
colmerge2to1pq now returns its merge sequence as (id1, id2, err) tuples
rather than (id1, id2) pairs, where err is the reconstruction error
(merge loss) incurred by each merge. The error was already computed
internally and discarded; surfacing it lets a caller merge all the way
down (n=1), locate a knee in the accumulating error, and replay the
corresponding prefix of the sequence with mergecolumns to stop there.

This is a breaking change: the element type of the returned sequence
widens from Tuple{Int,Int} to Tuple{Int,Int,Float64}.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
