### PR TITLE
Add errstop early-stopping keyword to colmerge2to1pq

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,9 +130,11 @@ Other keywords arguments are passed to ``NMF.nnmf``.
 -----
 Suppose you have the NMF solution ``W`` and ``H`` with ``r`` componenents, **colmerge2to1pq** function can merge ``r`` components to ``n``components. The details of this function is:
 
-**colmerge2to1pq**(W, H, n)
+**colmerge2to1pq**(W, H, n; errstop=nothing)
 
 This function merges components in ``W`` and ``H`` (columns in ``W`` and rows in ``H``) from original number of components to ``n`` components (``n``columns and rows left in ``W`` and ``H`` respectively).
+
+The keyword ``errstop`` stops merging early once the cheapest available merge would cost more than ``errstop`` (compared against the merge penalty), leaving more than ``n`` components; ``n`` then acts as a floor.
 
 To use this function:
 `Wmerge, Hmerge, mergeseq = colmerge2to1pq(W, H, n)`, where ``Wmerge`` and ``Hmerge`` are the merged results with ``n`` components. ``mergeseq`` is the sequence of merges as ``(id1, id2, err)`` tuples, where ``id1`` and ``id2`` are the merged component ids and ``err`` is the reconstruction error incurred by that merge. Merging all the way down (``n=1``) and inspecting the ``err`` values lets you locate a "knee" at which to stop, then replay the corresponding prefix of ``mergeseq`` with ``mergecolumns``.

--- a/README.md
+++ b/README.md
@@ -128,16 +128,18 @@ If one of ``W0`` and ``H0`` is ``nothing``, NNDSVD is used for initialization.
 Other keywords arguments are passed to ``NMF.nnmf``.
 
 -----
-Suppose you have the NMF solution ``W`` and ``H`` with ``r`` componenents, **colmerge2to1pq** function can merge ``r`` components to ``n``components. The details of this function is:
+Suppose you have the NMF solution ``W`` and ``H`` with ``r`` componenents, **colmerge2to1pq** function can merge ``r`` components down. The details of this function is:
 
-**colmerge2to1pq**(W, H, n; errstop=nothing)
+**colmerge2to1pq**(W, H; nstop=1, errstop=typemax(...))
 
-This function merges components in ``W`` and ``H`` (columns in ``W`` and rows in ``H``) from original number of components to ``n`` components (``n``columns and rows left in ``W`` and ``H`` respectively).
+This function merges components in ``W`` and ``H`` (columns in ``W`` and rows in ``H``). Merging stops at whichever of the two criteria ``nstop`` and ``errstop`` is reached first.
 
-The keyword ``errstop`` stops merging early once the cheapest available merge would cost more than ``errstop`` (compared against the merge penalty), leaving more than ``n`` components; ``n`` then acts as a floor.
+The keyword ``nstop`` is a floor on the number of components: merging never produces fewer than ``nstop`` components. The default ``nstop=1`` merges as far as possible.
+
+The keyword ``errstop`` stops merging early once the cheapest available merge would cost more than ``errstop`` (compared against the merge penalty), leaving more than ``nstop`` components. Its default disables early stopping.
 
 To use this function:
-`Wmerge, Hmerge, mergeseq = colmerge2to1pq(W, H, n)`, where ``Wmerge`` and ``Hmerge`` are the merged results with ``n`` components. ``mergeseq`` is the sequence of merges as ``(id1, id2, err)`` tuples, where ``id1`` and ``id2`` are the merged component ids and ``err`` is the reconstruction error incurred by that merge. Merging all the way down (``n=1``) and inspecting the ``err`` values lets you locate a "knee" at which to stop, then replay the corresponding prefix of ``mergeseq`` with ``mergecolumns``.
+`Wmerge, Hmerge, mergeseq = colmerge2to1pq(W, H; nstop=n)`, where ``Wmerge`` and ``Hmerge`` are the merged results with ``n`` components. ``mergeseq`` is the sequence of merges as ``(id1, id2, err)`` tuples, where ``id1`` and ``id2`` are the merged component ids and ``err`` is the reconstruction error incurred by that merge. Merging all the way down (``nstop=1``) and inspecting the ``err`` values lets you locate a "knee" at which to stop, then replay the corresponding prefix of ``mergeseq`` with ``mergecolumns``.
 
 -----
 

--- a/src/NMFMerge.jl
+++ b/src/NMFMerge.jl
@@ -61,7 +61,7 @@ function nmfmerge(queuepenalty, X, ncomponents::Pair{Int,Int}; tol_final=1e-4, t
     result_over = nnmf(X, n1; kwargs..., init=:custom, tol=tol_intermediate, W0=W_over_init, H0=H_over_init)
     W_over, H_over = result_over.W, result_over.H
     W_over_normed, H_over_normed = colnormalize(W_over, H_over)
-    Wmerge, Hmerge, _ = colmerge2to1pq(queuepenalty, W_over_normed, H_over_normed, n2)
+    Wmerge, Hmerge, _ = colmerge2to1pq(queuepenalty, W_over_normed, H_over_normed; nstop=n2)
     result_renmf = nnmf(X, n2; kwargs..., init=:custom, tol=tol_final, W0=Wmerge, H0=Hmerge)
     return result_renmf
 end
@@ -92,10 +92,10 @@ Normalize the factorization so that each column satisfies `||W[:, i]||_p ≈ 1`.
 colnormalize(W, H, p::Integer=2) = colnormalize!(float(copy(W)), float(copy(H)), p)
 
 """
-    Wmerge, Hmerge, mergeseq = colmerge2to1pq([queuepenalty], W::AbstractArray, H::AbstractArray, n::Integer; errstop=nothing)
+    Wmerge, Hmerge, mergeseq = colmerge2to1pq([queuepenalty], W::AbstractArray, H::AbstractArray; nstop=1, errstop=typemax(...))
 
-Merge components in `W` and `H` (columns in `W` and rows in `H`) until only `n`
-components remain.
+Merge components in `W` and `H` (columns in `W` and rows in `H`). Merging stops
+at whichever of the two criteria `nstop` and `errstop` is reached first.
 
 Arguments:
 
@@ -105,31 +105,32 @@ Arguments:
 
 - `H::AbstractArray`: The coefficient matrix.
 
-- `n::Integer`: The final number of components after merging. Merging never
-  produces fewer than `n` components, so `n` acts as a floor; pass `n=1` to
-  merge as far as possible.
-
 Keyword arguments:
 
-- `errstop`: stop early once the cheapest available merge would cost more than
-  `errstop`, leaving more than `n` components. The threshold is compared against
-  the `queuepenalty` value; under the default penalty this is the merge error.
-  `nothing` (the default) disables early stopping, so merging proceeds until `n`
-  components remain.
+- `nstop::Integer` (default: 1): a floor on the number of components. Merging never produces
+  fewer than `nstop` components. The default `nstop=1` merges to a single component.
+
+- `errstop` (default: `typemax(...)`): a ceiling on the per-merge cost. Merging never performs a merge
+  costing more than `errstop`. The cost is the `queuepenalty` value; under the
+  default penalty it is the merge error.
+
+The defaults on these keywords allow merging all the way down to a single component.
 
 Outputs:
 
-`Wmerge` and `Hmerge` are the merged results with `n` components.
+`Wmerge` and `Hmerge` are the merged results; the number of surviving components
+is `nstop` unless `errstop` stopped merging earlier.
 
 `mergeseq` is the sequence of merges as `(id1, id2, err)` tuples, in the order
 they were performed. `id1` and `id2` are the ids of the merged components and
 `err` is the reconstruction error (the merge penalty) incurred by that merge.
 Ids larger than the number of columns in `W` refer to components produced by
 earlier merges. The accumulating `err` values let a caller merge all the way
-down (`n == 1`) and locate a "knee" at which to stop, then replay the
+down (`nstop == 1`) and locate a "knee" at which to stop, then replay the
 corresponding prefix of `mergeseq` with [`mergecolumns`](@ref).
 """
-function colmerge2to1pq(queuepenalty, S::AbstractArray, T::AbstractArray, n::Integer; errstop=nothing)
+function colmerge2to1pq(queuepenalty, S::AbstractArray, T::AbstractArray;
+                        nstop::Integer=1, errstop=typemax(promote_type(eltype(S), eltype(T))))
     mrgseq = Tuple{Int, Int, Float64}[]
     S = let S = S    # julia #15276
         [S[:, j] for j in axes(S, 2)]
@@ -143,19 +144,19 @@ function colmerge2to1pq(queuepenalty, S::AbstractArray, T::AbstractArray, n::Int
     end
     Nt = length(S)
     Nt >= 2 || throw(ArgumentError("Cannot do 2 to 1 merge: Matrix size smaller than 2"))
-    Nt >= n || throw(ArgumentError("Final solution more than original size"))
+    Nt >= nstop || throw(ArgumentError("Final solution more than original size"))
     pq = PriorityQueue{Tuple{Int,Int},Float64}()
     for id0 in length(S):-1:2
         pq = pqupdate2to1!(queuepenalty, pq, S, T, id0, 1:id0-1)
     end
     m = Nt
-    while m > n && !isempty(pq)
+    while m > nstop && !isempty(pq)
         (id0, id1), penalty = first(pq)
         if isempty(S[id0])||isempty(S[id1])
             popfirst!(pq)
             continue
         end
-        errstop !== nothing && penalty > errstop && break
+        penalty > errstop && break
         popfirst!(pq)
         S, T, id01, loss = mergecol2to1!(S, T, id0, id1)
         push!(mrgseq, (id0, id1, loss))
@@ -165,7 +166,7 @@ function colmerge2to1pq(queuepenalty, S::AbstractArray, T::AbstractArray, n::Int
     Smtx, Tmtx = reduce(hcat, filter(!isempty, S)), reduce(hcat, filter(!isempty, T))'
     return Smtx, Matrix(Tmtx), mrgseq
 end
-colmerge2to1pq(S::AbstractArray, T::AbstractArray, n::Integer; kwargs...) = colmerge2to1pq(mergepenalty, S, T, n; kwargs...)
+colmerge2to1pq(S::AbstractArray, T::AbstractArray; kwargs...) = colmerge2to1pq(mergepenalty, S, T; kwargs...)
 
 function pqupdate2to1!(queuepenalty::Function, pq, S::AbstractVector, T::AbstractVector, id01::Integer, overlapids::AbstractRange{To}) where To
     for id in overlapids

--- a/src/NMFMerge.jl
+++ b/src/NMFMerge.jl
@@ -92,7 +92,7 @@ Normalize the factorization so that each column satisfies `||W[:, i]||_p ≈ 1`.
 colnormalize(W, H, p::Integer=2) = colnormalize!(float(copy(W)), float(copy(H)), p)
 
 """
-    Wmerge, Hmerge, mergeseq = colmerge2to1pq([queuepenalty], W::AbstractArray, H::AbstractArray, n::Integer)
+    Wmerge, Hmerge, mergeseq = colmerge2to1pq([queuepenalty], W::AbstractArray, H::AbstractArray, n::Integer; errstop=nothing)
 
 Merge components in `W` and `H` (columns in `W` and rows in `H`) until only `n`
 components remain.
@@ -105,7 +105,17 @@ Arguments:
 
 - `H::AbstractArray`: The coefficient matrix.
 
-- `n::Integer`: The final number of components after merging.
+- `n::Integer`: The final number of components after merging. Merging never
+  produces fewer than `n` components, so `n` acts as a floor; pass `n=1` to
+  merge as far as possible.
+
+Keyword arguments:
+
+- `errstop`: stop early once the cheapest available merge would cost more than
+  `errstop`, leaving more than `n` components. The threshold is compared against
+  the `queuepenalty` value; under the default penalty this is the merge error.
+  `nothing` (the default) disables early stopping, so merging proceeds until `n`
+  components remain.
 
 Outputs:
 
@@ -119,7 +129,7 @@ earlier merges. The accumulating `err` values let a caller merge all the way
 down (`n == 1`) and locate a "knee" at which to stop, then replay the
 corresponding prefix of `mergeseq` with [`mergecolumns`](@ref).
 """
-function colmerge2to1pq(queuepenalty, S::AbstractArray, T::AbstractArray, n::Integer)
+function colmerge2to1pq(queuepenalty, S::AbstractArray, T::AbstractArray, n::Integer; errstop=nothing)
     mrgseq = Tuple{Int, Int, Float64}[]
     S = let S = S    # julia #15276
         [S[:, j] for j in axes(S, 2)]
@@ -139,11 +149,14 @@ function colmerge2to1pq(queuepenalty, S::AbstractArray, T::AbstractArray, n::Int
         pq = pqupdate2to1!(queuepenalty, pq, S, T, id0, 1:id0-1)
     end
     m = Nt
-    while m > n
-        id0, id1 = popfirst!(pq).first
+    while m > n && !isempty(pq)
+        (id0, id1), penalty = first(pq)
         if isempty(S[id0])||isempty(S[id1])
+            popfirst!(pq)
             continue
         end
+        errstop !== nothing && penalty > errstop && break
+        popfirst!(pq)
         S, T, id01, loss = mergecol2to1!(S, T, id0, id1)
         push!(mrgseq, (id0, id1, loss))
         pqupdate2to1!(queuepenalty, pq, S, T, id01, 1:id01-1);
@@ -152,7 +165,7 @@ function colmerge2to1pq(queuepenalty, S::AbstractArray, T::AbstractArray, n::Int
     Smtx, Tmtx = reduce(hcat, filter(!isempty, S)), reduce(hcat, filter(!isempty, T))'
     return Smtx, Matrix(Tmtx), mrgseq
 end
-colmerge2to1pq(S::AbstractArray, T::AbstractArray, n::Integer) = colmerge2to1pq(mergepenalty, S, T, n)
+colmerge2to1pq(S::AbstractArray, T::AbstractArray, n::Integer; kwargs...) = colmerge2to1pq(mergepenalty, S, T, n; kwargs...)
 
 function pqupdate2to1!(queuepenalty::Function, pq, S::AbstractVector, T::AbstractVector, id01::Integer, overlapids::AbstractRange{To}) where To
     for id in overlapids

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -190,7 +190,7 @@ end
     Wn, Hn = colnormalize(W, H)
     @test sum(abs2, W*H - Wn*Hn) < 1e-16
 
-    Wm, Hm, mergids = colmerge2to1pq(copy(Wn), copy(Hn), 2)
+    Wm, Hm, mergids = colmerge2to1pq(copy(Wn), copy(Hn); nstop=2)
     Wn1 = [Wn[:, j] for j in axes(Wn, 2)];
     Hn1 = [Hn[i, :] for i in axes(Hn, 1)];
     Ids = [(1,2), (1,3), (2,3)]
@@ -218,7 +218,7 @@ end
     wrand1 ./= norm(wrand1)
     Ws = [wrand zeros(5) wrand wrand1]
     Hs = [rand(10) rand(10) zeros(10) rand(10)]'
-    Wmerge, Hmerge, _ = colmerge2to1pq(Ws, Hs, 1)
+    Wmerge, Hmerge, _ = colmerge2to1pq(Ws, Hs; nstop=1)
     @test size(Wmerge, 2) == 1
 
     W14, H14, _ = NMFMerge.mergepair([Ws[:,1], Ws[:,4]], [Hs[1,:], Hs[4,:]], 1, 2)
@@ -239,8 +239,8 @@ end
         push!(idpair_loss, ((id1, id2), loss2))
     end
     idpair_loss = sort(idpair_loss, by=x->x[2])
-    merge_sequence = colmerge2to1pq(Wsn, Hsn, 1)[end]
-    merge_sequence_custom = colmerge2to1pq(mergepenalty_custom, Wsn, Hsn, 1)[end]
+    merge_sequence = colmerge2to1pq(Wsn, Hsn; nstop=1)[end]
+    merge_sequence_custom = colmerge2to1pq(mergepenalty_custom, Wsn, Hsn; nstop=1)[end]
     @test merge_sequence[1][1:2] == idpair_loss[1][1]
     @test merge_sequence_custom[1][1:2] == idpair_loss[3][1]
 
@@ -251,7 +251,7 @@ end
     ncols = size(Wn, 2)
 
     # Merge all the way down to a single component, recording every merge error.
-    Wfull, Hfull, schedule = colmerge2to1pq(Wn, Hn, 1)
+    Wfull, Hfull, schedule = colmerge2to1pq(Wn, Hn; nstop=1)
     @test size(Wfull, 2) == 1
     @test length(schedule) == ncols - 1
     errs = [s[3] for s in schedule]
@@ -267,7 +267,7 @@ end
     # Knee: stopping the merge at rank k equals replaying the first ncols-k
     # merges of the full schedule.
     for k in 1:ncols-1
-        Wk, Hk, _ = colmerge2to1pq(Wn, Hn, k)
+        Wk, Hk, _ = colmerge2to1pq(Wn, Hn; nstop=k)
         Wkr, Hkr, _, _ = mergecolumns(Wn, Hn, schedule[1:ncols-k])
         @test size(Wkr, 2) == k
         @test Wkr ≈ Wk
@@ -278,29 +278,29 @@ end
 @testset "errstop stopping criterion" begin
     Wn, Hn = colnormalize(float.(W_GT), float.(H_GT))
     ncols = size(Wn, 2)
-    _, _, schedule = colmerge2to1pq(Wn, Hn, 1)
+    _, _, schedule = colmerge2to1pq(Wn, Hn; nstop=1)
     errs = [s[3] for s in schedule]
     @test issorted(errs)  # the cut tests below rely on increasing merge errors
 
     # A threshold between two successive merge errors stops just before the
-    # costlier merge, leaving more than the floor `n` components.
+    # costlier merge, leaving more than the `nstop` floor of components.
     thresh = (errs[2] + errs[3]) / 2
-    W2, _, seq2 = colmerge2to1pq(Wn, Hn, 1; errstop=thresh)
+    W2, _, seq2 = colmerge2to1pq(Wn, Hn; nstop=1, errstop=thresh)
     @test length(seq2) == 2
     @test size(W2, 2) == ncols - 2
 
     # A threshold below the cheapest merge performs no merges.
-    W0, _, seq0 = colmerge2to1pq(Wn, Hn, 1; errstop=errs[1] - 1)
+    W0, _, seq0 = colmerge2to1pq(Wn, Hn; nstop=1, errstop=errs[1] - 1)
     @test isempty(seq0)
     @test size(W0, 2) == ncols
 
-    # The positional `n` floor still caps merging even when errstop permits more.
-    Wf, _, seqf = colmerge2to1pq(Wn, Hn, ncols - 1; errstop=Inf)
+    # The `nstop` floor still caps merging even when errstop permits more.
+    Wf, _, seqf = colmerge2to1pq(Wn, Hn; nstop=ncols - 1, errstop=Inf)
     @test length(seqf) == 1
     @test size(Wf, 2) == ncols - 1
 
-    # errstop=nothing reproduces the unrestricted merge.
-    Wd, _, seqd = colmerge2to1pq(Wn, Hn, 1; errstop=nothing)
+    # The default errstop reproduces the unrestricted merge.
+    Wd, _, seqd = colmerge2to1pq(Wn, Hn; nstop=1)
     @test length(seqd) == length(schedule)
     @test size(Wd, 2) == 1
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -274,3 +274,33 @@ end
         @test Hkr ≈ Hk
     end
 end
+
+@testset "errstop stopping criterion" begin
+    Wn, Hn = colnormalize(float.(W_GT), float.(H_GT))
+    ncols = size(Wn, 2)
+    _, _, schedule = colmerge2to1pq(Wn, Hn, 1)
+    errs = [s[3] for s in schedule]
+    @test issorted(errs)  # the cut tests below rely on increasing merge errors
+
+    # A threshold between two successive merge errors stops just before the
+    # costlier merge, leaving more than the floor `n` components.
+    thresh = (errs[2] + errs[3]) / 2
+    W2, _, seq2 = colmerge2to1pq(Wn, Hn, 1; errstop=thresh)
+    @test length(seq2) == 2
+    @test size(W2, 2) == ncols - 2
+
+    # A threshold below the cheapest merge performs no merges.
+    W0, _, seq0 = colmerge2to1pq(Wn, Hn, 1; errstop=errs[1] - 1)
+    @test isempty(seq0)
+    @test size(W0, 2) == ncols
+
+    # The positional `n` floor still caps merging even when errstop permits more.
+    Wf, _, seqf = colmerge2to1pq(Wn, Hn, ncols - 1; errstop=Inf)
+    @test length(seqf) == 1
+    @test size(Wf, 2) == ncols - 1
+
+    # errstop=nothing reproduces the unrestricted merge.
+    Wd, _, seqd = colmerge2to1pq(Wn, Hn, 1; errstop=nothing)
+    @test length(seqd) == length(schedule)
+    @test size(Wd, 2) == 1
+end


### PR DESCRIPTION
`colmerge2to1pq` moves the target number to a keyword `nstop` and gains an `errstop` keyword. Merging halts whenever one of these criteria is met.
