### PR TITLE
Rename colmerge2to1pq to merge_pq

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,9 +128,9 @@ If one of ``W0`` and ``H0`` is ``nothing``, NNDSVD is used for initialization.
 Other keywords arguments are passed to ``NMF.nnmf``.
 
 -----
-Suppose you have the NMF solution ``W`` and ``H`` with ``r`` componenents, **colmerge2to1pq** function can merge ``r`` components down. The details of this function is:
+Suppose you have the NMF solution ``W`` and ``H`` with ``r`` componenents, **merge_pq** function can merge ``r`` components down. The details of this function is:
 
-**colmerge2to1pq**(W, H; nstop=1, errstop=typemax(...))
+**merge_pq**(W, H; nstop=1, errstop=typemax(...))
 
 This function merges components in ``W`` and ``H`` (columns in ``W`` and rows in ``H``). Merging stops at whichever of the two criteria ``nstop`` and ``errstop`` is reached first.
 
@@ -139,7 +139,7 @@ The keyword ``nstop`` is a floor on the number of components: merging never prod
 The keyword ``errstop`` stops merging early once the cheapest available merge would cost more than ``errstop`` (compared against the merge penalty), leaving more than ``nstop`` components. Its default disables early stopping.
 
 To use this function:
-`Wmerge, Hmerge, mergeseq = colmerge2to1pq(W, H; nstop=n)`, where ``Wmerge`` and ``Hmerge`` are the merged results with ``n`` components. ``mergeseq`` is the sequence of merges as ``(id1, id2, err)`` tuples, where ``id1`` and ``id2`` are the merged component ids and ``err`` is the reconstruction error incurred by that merge. Merging all the way down (``nstop=1``) and inspecting the ``err`` values lets you locate a "knee" at which to stop, then replay the corresponding prefix of ``mergeseq`` with ``mergecolumns``.
+`Wmerge, Hmerge, mergeseq = merge_pq(W, H; nstop=n)`, where ``Wmerge`` and ``Hmerge`` are the merged results with ``n`` components. ``mergeseq`` is the sequence of merges as ``(id1, id2, err)`` tuples, where ``id1`` and ``id2`` are the merged component ids and ``err`` is the reconstruction error incurred by that merge. Merging all the way down (``nstop=1``) and inspecting the ``err`` values lets you locate a "knee" at which to stop, then replay the corresponding prefix of ``mergeseq`` with ``mergecolumns``.
 
 -----
 

--- a/src/NMFMerge.jl
+++ b/src/NMFMerge.jl
@@ -8,7 +8,7 @@ using TSVD: TSVD, tsvd
 
 export nmfmerge,
        colnormalize,
-       colmerge2to1pq,
+       merge_pq,
        mergecolumns
 
 @static if VERSION >= v"1.11"
@@ -67,7 +67,7 @@ function nmfmerge(queuepenalty, X, ncomponents::Pair{Int,Int}; tol_final=1e-4, t
     result_over = nnmf(X, n1; kwargs..., init=:custom, tol=tol_intermediate, W0=W_over_init, H0=H_over_init)
     W_over, H_over = result_over.W, result_over.H
     W_over_normed, H_over_normed = colnormalize(W_over, H_over)
-    Wmerge, Hmerge, _ = colmerge2to1pq(queuepenalty, W_over_normed, H_over_normed; nstop=n2)
+    Wmerge, Hmerge, _ = merge_pq(queuepenalty, W_over_normed, H_over_normed; nstop=n2)
     result_renmf = nnmf(X, n2; kwargs..., init=:custom, tol=tol_final, W0=Wmerge, H0=Hmerge)
     return result_renmf
 end
@@ -98,7 +98,7 @@ Normalize the factorization so that each column satisfies `||W[:, i]||_p ≈ 1`.
 colnormalize(W, H, p::Integer=2) = colnormalize!(float(copy(W)), float(copy(H)), p)
 
 """
-    Wmerge, Hmerge, mergeseq = colmerge2to1pq([queuepenalty], W::AbstractArray, H::AbstractArray; nstop=1, errstop=typemax(...))
+    Wmerge, Hmerge, mergeseq = merge_pq([queuepenalty], W::AbstractArray, H::AbstractArray; nstop=1, errstop=typemax(...))
 
 Merge components in `W` and `H` (columns in `W` and rows in `H`). Merging stops
 at whichever of the two criteria `nstop` and `errstop` is reached first.
@@ -135,44 +135,44 @@ earlier merges. The accumulating `err` values let a caller merge all the way
 down (`nstop == 1`) and locate a "knee" at which to stop, then replay the
 corresponding prefix of `mergeseq` with [`mergecolumns`](@ref).
 """
-function colmerge2to1pq(queuepenalty, S::AbstractArray, T::AbstractArray;
-                        nstop::Integer=1, errstop=typemax(promote_type(eltype(S), eltype(T))))
+function merge_pq(queuepenalty, W::AbstractArray, H::AbstractArray;
+                  nstop::Integer=1, errstop=typemax(promote_type(eltype(W), eltype(H))))
     mrgseq = Tuple{Int, Int, Float64}[]
-    S = let S = S    # julia #15276
-        [S[:, j] for j in axes(S, 2)]
+    W = let W = W    # julia #15276
+        [W[:, j] for j in axes(W, 2)]
     end
-    T = let T = T
-        [T[i, :] for i in axes(T, 1)]
+    H = let H = H
+        [H[i, :] for i in axes(H, 1)]
     end
-    for (id, s) in enumerate(S)
-        snorm = norm(s)
-        (abs(snorm-1)<1e-12 || iszero(snorm)) || throw(ArgumentError("W columns must be normalized, $(id)-th column norm = $(snorm)"))
+    for (id, w) in enumerate(W)
+        wnorm = norm(w)
+        (abs(wnorm-1)<1e-12 || iszero(wnorm)) || throw(ArgumentError("W columns must be normalized, $(id)-th column norm = $(wnorm)"))
     end
-    Nt = length(S)
+    Nt = length(W)
     Nt >= 2 || throw(ArgumentError("Cannot do 2 to 1 merge: Matrix size smaller than 2"))
     Nt >= nstop || throw(ArgumentError("Final solution more than original size"))
     pq = PriorityQueue{Tuple{Int,Int},Float64}()
-    for id0 in length(S):-1:2
-        pq = pqupdate2to1!(queuepenalty, pq, S, T, id0, 1:id0-1)
+    for id0 in length(W):-1:2
+        pq = pqupdate2to1!(queuepenalty, pq, W, H, id0, 1:id0-1)
     end
     m = Nt
     while m > nstop && !isempty(pq)
         (id0, id1), penalty = first(pq)
-        if isempty(S[id0])||isempty(S[id1])
+        if isempty(W[id0])||isempty(W[id1])
             popfirst!(pq)
             continue
         end
         penalty > errstop && break
         popfirst!(pq)
-        S, T, id01, loss = mergecol2to1!(S, T, id0, id1)
+        W, H, id01, loss = mergecol2to1!(W, H, id0, id1)
         push!(mrgseq, (id0, id1, loss))
-        pqupdate2to1!(queuepenalty, pq, S, T, id01, 1:id01-1);
+        pqupdate2to1!(queuepenalty, pq, W, H, id01, 1:id01-1);
         m -= 1
     end
-    Smtx, Tmtx = reduce(hcat, filter(!isempty, S)), reduce(hcat, filter(!isempty, T))'
-    return Smtx, Matrix(Tmtx), mrgseq
+    Wmtx, Hmtx = reduce(hcat, filter(!isempty, W)), reduce(hcat, filter(!isempty, H))'
+    return Wmtx, Matrix(Hmtx), mrgseq
 end
-colmerge2to1pq(S::AbstractArray, T::AbstractArray; kwargs...) = colmerge2to1pq(ssdpenalty, S, T; kwargs...)
+merge_pq(W::AbstractArray, H::AbstractArray; kwargs...) = merge_pq(ssdpenalty, W, H; kwargs...)
 
 function pqupdate2to1!(queuepenalty::Function, pq, S::AbstractVector, T::AbstractVector, id01::Integer, overlapids::AbstractRange{To}) where To
     for id in overlapids
@@ -277,7 +277,7 @@ end
     ssdpenalty(E, h1sq, h2sq)
 
 The default merge penalty: the merge error `E` itself, ignoring the squared
-norms `h1sq`, `h2sq` of the two `H` rows. With this penalty `colmerge2to1pq`
+norms `h1sq`, `h2sq` of the two `H` rows. With this penalty `merge_pq`
 and `nmfmerge` merge purely in order of increasing reconstruction error.
 
 Pass a custom `f(E, h1sq, h2sq)` as the leading argument to those functions to

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -190,7 +190,7 @@ end
     Wn, Hn = colnormalize(W, H)
     @test sum(abs2, W*H - Wn*Hn) < 1e-16
 
-    Wm, Hm, mergids = colmerge2to1pq(copy(Wn), copy(Hn); nstop=2)
+    Wm, Hm, mergids = merge_pq(copy(Wn), copy(Hn); nstop=2)
     Wn1 = [Wn[:, j] for j in axes(Wn, 2)];
     Hn1 = [Hn[i, :] for i in axes(Hn, 1)];
     Ids = [(1,2), (1,3), (2,3)]
@@ -218,7 +218,7 @@ end
     wrand1 ./= norm(wrand1)
     Ws = [wrand zeros(5) wrand wrand1]
     Hs = [rand(10) rand(10) zeros(10) rand(10)]'
-    Wmerge, Hmerge, _ = colmerge2to1pq(Ws, Hs; nstop=1)
+    Wmerge, Hmerge, _ = merge_pq(Ws, Hs; nstop=1)
     @test size(Wmerge, 2) == 1
 
     W14, H14, _ = NMFMerge.mergepair([Ws[:,1], Ws[:,4]], [Hs[1,:], Hs[4,:]], 1, 2)
@@ -239,8 +239,8 @@ end
         push!(idpair_loss, ((id1, id2), loss2))
     end
     idpair_loss = sort(idpair_loss, by=x->x[2])
-    merge_sequence = colmerge2to1pq(Wsn, Hsn; nstop=1)[end]
-    merge_sequence_custom = colmerge2to1pq(mergepenalty_custom, Wsn, Hsn; nstop=1)[end]
+    merge_sequence = merge_pq(Wsn, Hsn; nstop=1)[end]
+    merge_sequence_custom = merge_pq(mergepenalty_custom, Wsn, Hsn; nstop=1)[end]
     @test merge_sequence[1][1:2] == idpair_loss[1][1]
     @test merge_sequence_custom[1][1:2] == idpair_loss[3][1]
 
@@ -251,14 +251,14 @@ end
     ncols = size(Wn, 2)
 
     # Merge all the way down to a single component, recording every merge error.
-    Wfull, Hfull, schedule = colmerge2to1pq(Wn, Hn; nstop=1)
+    Wfull, Hfull, schedule = merge_pq(Wn, Hn; nstop=1)
     @test size(Wfull, 2) == 1
     @test length(schedule) == ncols - 1
     errs = [s[3] for s in schedule]
     @test all(>=(0), errs)
 
     # Replaying the full schedule reproduces the final factors and the same
-    # per-merge errors that colmerge2to1pq reported.
+    # per-merge errors that merge_pq reported.
     Wr, Hr, _, Err = mergecolumns(Wn, Hn, schedule)
     @test Err ≈ errs
     @test Wr ≈ Wfull
@@ -267,7 +267,7 @@ end
     # Knee: stopping the merge at rank k equals replaying the first ncols-k
     # merges of the full schedule.
     for k in 1:ncols-1
-        Wk, Hk, _ = colmerge2to1pq(Wn, Hn; nstop=k)
+        Wk, Hk, _ = merge_pq(Wn, Hn; nstop=k)
         Wkr, Hkr, _, _ = mergecolumns(Wn, Hn, schedule[1:ncols-k])
         @test size(Wkr, 2) == k
         @test Wkr ≈ Wk
@@ -278,29 +278,29 @@ end
 @testset "errstop stopping criterion" begin
     Wn, Hn = colnormalize(float.(W_GT), float.(H_GT))
     ncols = size(Wn, 2)
-    _, _, schedule = colmerge2to1pq(Wn, Hn; nstop=1)
+    _, _, schedule = merge_pq(Wn, Hn; nstop=1)
     errs = [s[3] for s in schedule]
     @test issorted(errs)  # the cut tests below rely on increasing merge errors
 
     # A threshold between two successive merge errors stops just before the
     # costlier merge, leaving more than the `nstop` floor of components.
     thresh = (errs[2] + errs[3]) / 2
-    W2, _, seq2 = colmerge2to1pq(Wn, Hn; nstop=1, errstop=thresh)
+    W2, _, seq2 = merge_pq(Wn, Hn; nstop=1, errstop=thresh)
     @test length(seq2) == 2
     @test size(W2, 2) == ncols - 2
 
     # A threshold below the cheapest merge performs no merges.
-    W0, _, seq0 = colmerge2to1pq(Wn, Hn; nstop=1, errstop=errs[1] - 1)
+    W0, _, seq0 = merge_pq(Wn, Hn; nstop=1, errstop=errs[1] - 1)
     @test isempty(seq0)
     @test size(W0, 2) == ncols
 
     # The `nstop` floor still caps merging even when errstop permits more.
-    Wf, _, seqf = colmerge2to1pq(Wn, Hn; nstop=ncols - 1, errstop=Inf)
+    Wf, _, seqf = merge_pq(Wn, Hn; nstop=ncols - 1, errstop=Inf)
     @test length(seqf) == 1
     @test size(Wf, 2) == ncols - 1
 
     # The default errstop reproduces the unrestricted merge.
-    Wd, _, seqd = colmerge2to1pq(Wn, Hn; nstop=1)
+    Wd, _, seqd = merge_pq(Wn, Hn; nstop=1)
     @test length(seqd) == length(schedule)
     @test size(Wd, 2) == 1
 end


### PR DESCRIPTION
The priority-queue 2-to-1 merge entry point is renamed merge_pq, and its
positional matrix arguments S, T are renamed W, H to match the basis/coefficient
naming used throughout the rest of the API and in this function's own docstring.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
