### PR TITLE
Rename mergecolumns to merge_replay and simplify its return

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,7 +139,7 @@ The keyword ``nstop`` is a floor on the number of components: merging never prod
 The keyword ``errstop`` stops merging early once the cheapest available merge would cost more than ``errstop`` (compared against the merge penalty), leaving more than ``nstop`` components. Its default disables early stopping.
 
 To use this function:
-`Wmerge, Hmerge, mergeseq = merge_pq(W, H; nstop=n)`, where ``Wmerge`` and ``Hmerge`` are the merged results with ``n`` components. ``mergeseq`` is the sequence of merges as ``(id1, id2, err)`` tuples, where ``id1`` and ``id2`` are the merged component ids and ``err`` is the reconstruction error incurred by that merge. Merging all the way down (``nstop=1``) and inspecting the ``err`` values lets you locate a "knee" at which to stop, then replay the corresponding prefix of ``mergeseq`` with ``mergecolumns``.
+`Wmerge, Hmerge, mergeseq = merge_pq(W, H; nstop=n)`, where ``Wmerge`` and ``Hmerge`` are the merged results with ``n`` components. ``mergeseq`` is the sequence of merges as ``(id1, id2, err)`` tuples, where ``id1`` and ``id2`` are the merged component ids and ``err`` is the reconstruction error incurred by that merge. Merging all the way down (``nstop=1``) and inspecting the ``err`` values lets you locate a "knee" at which to stop, then replay the corresponding prefix of ``mergeseq`` with ``merge_replay``.
 
 -----
 
@@ -159,13 +159,11 @@ To use this function:
 
 If you already have a merge sequence and want to merge from ``size(W, 2)`` components to ``n`` components, you can use the function:
 
-**mergecolumns**(W, H, mergeseq; tracemerge)
-
-keyword argurment ``tracemerge``: save ``Wmerge`` and ``Hmerge`` at each merge stage if ``tracemerge=true``. default ``tracemerge=false``.
+**merge_replay**(W, H, mergeseq)
 
 To use this function:
 
-`Wmerge, Hmerge, WHstage, Err = mergecolumns(W, H, mergeseq; tracemerge)`, where ``Wmerge`` and ``Hmerge`` are the merged results. ``WHstage::Vector{Tuple{Matrix, Matrix}}`` includes the results of each merge stage. ``WHstage=[]`` if ``tracemerge=false``. ``Err::Vector`` includes merge penalty of each merge stage.
+`Wmerge, Hmerge = merge_replay(W, H, mergeseq)`, where ``Wmerge`` and ``Hmerge`` are the merged results. Each entry of ``mergeseq`` supplies the pair of ids ``(id1, id2)`` to merge; any further fields are ignored, so the ``(id1, id2, err)`` triples returned by ``merge_pq`` can be replayed directly.
 
 ## Citation
 Thanks for citing this work! See the "Cite this repository" link in the "About" bar for format options.

--- a/src/NMFMerge.jl
+++ b/src/NMFMerge.jl
@@ -9,7 +9,7 @@ using TSVD: TSVD, tsvd
 export nmfmerge,
        colnormalize,
        merge_pq,
-       mergecolumns
+       merge_replay
 
 @static if VERSION >= v"1.11"
     # `public` is a parse error before 1.11, so build the declaration as an
@@ -133,7 +133,7 @@ they were performed. `id1` and `id2` are the ids of the merged components and
 Ids larger than the number of columns in `W` refer to components produced by
 earlier merges. The accumulating `err` values let a caller merge all the way
 down (`nstop == 1`) and locate a "knee" at which to stop, then replay the
-corresponding prefix of `mergeseq` with [`mergecolumns`](@ref).
+corresponding prefix of `mergeseq` with [`merge_replay`](@ref).
 """
 function merge_pq(queuepenalty, W::AbstractArray, H::AbstractArray;
                   nstop::Integer=1, errstop=typemax(promote_type(eltype(W), eltype(H))))
@@ -245,32 +245,26 @@ function remix_enact(S::AbstractVector{TS}, T::AbstractVector, id1::Integer, id2
 end
 
 """
-    Wmerge, Hmerge, WHstage, Err = mergecolumns(W, H, mergeseq; tracemerge=false)
+    Wmerge, Hmerge = merge_replay(W, H, mergeseq)
 
-Merge components in `W` and `H` (columns in `W` and rows in `H`) according to the sequence of merge pair ids `mergeseq`.
+Merge components in `W` and `H` (columns in `W` and rows in `H`) by replaying the
+sequence of merge-pair ids in `mergeseq`, returning the merged factors.
 
-`Wmerge` and `Hmerge` are the merged results.
-
-`WHstage::Vector{Tuple{Matrix, Matrix}}` includes the results of each merge stage. `WHstage` is empty if `tracemerge=false`.
-
-`Err::Vector` includes merge penalty of each merge stage.
+Each entry of `mergeseq` supplies the pair of ids `(id1, id2)` to merge; any
+further fields are ignored, so the `(id1, id2, err)` triples returned by
+[`merge_pq`](@ref) can be replayed directly. Replaying a prefix of a `merge_pq`
+schedule reproduces the factors `merge_pq` would have returned had it stopped at
+the corresponding number of components.
 """
-function mergecolumns(W::AbstractArray, H::AbstractArray, mergeseq::AbstractArray; tracemerge::Bool = false)
-    Err = Float64[]
-    S = [W[:, j] for j in axes(W, 2)]
-    T = [H[i, :] for i in axes(H, 1)]
-    STstage = []
+function merge_replay(W::AbstractArray, H::AbstractArray, mergeseq::AbstractArray)
+    W = [W[:, j] for j in axes(W, 2)]
+    H = [H[i, :] for i in axes(H, 1)]
     for mergeids in mergeseq
         id0, id1 = mergeids
-        if tracemerge
-            push!(STstage, (copy(S), copy(T)))
-        end
-        S, T, _, loss = mergecol2to1!(S, T, id0, id1)
-        err = loss
-        push!(Err, err)
+        W, H, _, _ = mergecol2to1!(W, H, id0, id1)
     end
-    Smtx, Tmtx = hcat(filter(x -> x != [], S)...), hcat(filter(x -> x != [], T)...)'
-    return Smtx, Matrix(Tmtx), STstage, Err
+    Wmtx, Hmtx = hcat(filter(!isempty, W)...), hcat(filter(!isempty, H)...)'
+    return Wmtx, Matrix(Hmtx)
 end
 
 """

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -257,10 +257,8 @@ end
     errs = [s[3] for s in schedule]
     @test all(>=(0), errs)
 
-    # Replaying the full schedule reproduces the final factors and the same
-    # per-merge errors that merge_pq reported.
-    Wr, Hr, _, Err = mergecolumns(Wn, Hn, schedule)
-    @test Err ≈ errs
+    # Replaying the full schedule reproduces the final factors.
+    Wr, Hr = merge_replay(Wn, Hn, schedule)
     @test Wr ≈ Wfull
     @test Hr ≈ Hfull
 
@@ -268,7 +266,7 @@ end
     # merges of the full schedule.
     for k in 1:ncols-1
         Wk, Hk, _ = merge_pq(Wn, Hn; nstop=k)
-        Wkr, Hkr, _, _ = mergecolumns(Wn, Hn, schedule[1:ncols-k])
+        Wkr, Hkr = merge_replay(Wn, Hn, schedule[1:ncols-k])
         @test size(Wkr, 2) == k
         @test Wkr ≈ Wk
         @test Hkr ≈ Hk


### PR DESCRIPTION
merge_replay(W, H, mergeseq) now returns only the merged (Wmerge, Hmerge). The
former WHstage stage-snapshot output, its tracemerge keyword, and the Err vector
are removed: the per-merge errors are already carried in the (id1, id2, err)
schedule returned by merge_pq, so replaying that schedule needs no separate error
report.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
