### PR TITLE
Accept any real norm order in colnormalize

### DIFF
--- a/src/NMFMerge.jl
+++ b/src/NMFMerge.jl
@@ -75,7 +75,7 @@ nmfmerge(queuepenalty, X, ncomponents::Integer; kwargs...) = nmfmerge(queuepenal
 nmfmerge(X, ncomponents::Pair{Int,Int}; kwargs...) = nmfmerge(ssdpenalty, X, ncomponents; kwargs...)
 nmfmerge(X, ncomponents::Integer; kwargs...) = nmfmerge(ssdpenalty, X, ncomponents::Integer; kwargs...)
 
-function colnormalize!(W, H, p::Integer=2)
+function colnormalize!(W, H, p::Real=2)
     nonzerocolids = Int[]
     for (j, w) in pairs(eachcol(W))
         normw = norm(w, p)
@@ -93,9 +93,11 @@ end
     Wnormalized, Hnormalized = colnormalize(W, H, p=2)
 
 Normalize the factorization so that each column satisfies `||W[:, i]||_p ≈ 1`.
+`p` is the norm order passed to `LinearAlgebra.norm`, so any real order is
+accepted (e.g. `1`, `2`, `Inf`).
 
 """
-colnormalize(W, H, p::Integer=2) = colnormalize!(float(copy(W)), float(copy(H)), p)
+colnormalize(W, H, p::Real=2) = colnormalize!(float(copy(W)), float(copy(H)), p)
 
 """
     Wmerge, Hmerge, mergeseq = merge_pq([queuepenalty], W::AbstractArray, H::AbstractArray; nstop=1, errstop=typemax(...))

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -122,6 +122,19 @@ end
     end
 end
 
+@testset "colnormalize norm order" begin
+    W = rand(6, 4)
+    H = rand(4, 9)
+    for p in (1, 2, Inf)
+        Wn, Hn = colnormalize(W, H, p)
+        # Columns of W are unit-`p`-norm and the factorization is preserved.
+        for j in axes(Wn, 2)
+            @test norm(Wn[:, j], p) ≈ 1
+        end
+        @test Wn * Hn ≈ W * H
+    end
+end
+
 @testset "Single-component image" begin
     ns = 31
     nt = 100


### PR DESCRIPTION
colnormalize and colnormalize! now take p::Real rather than p::Integer, matching
LinearAlgebra.norm: orders such as Inf are valid and no longer raise a
MethodError. The norm order is documented and exercised for p in (1, 2, Inf).

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
