### PR TITLE
Require unit 2-norm columns explicitly in merge_pq

### DIFF
--- a/src/NMFMerge.jl
+++ b/src/NMFMerge.jl
@@ -96,6 +96,10 @@ Normalize the factorization so that each column satisfies `||W[:, i]||_p ≈ 1`.
 `p` is the norm order passed to `LinearAlgebra.norm`, so any real order is
 accepted (e.g. `1`, `2`, `Inf`).
 
+[`merge_pq`](@ref) and [`nmfmerge`](@ref) require unit *2-norm* columns, so use
+the default `p=2` when preparing input for the merge. Other orders are available
+for unrelated normalization needs.
+
 """
 colnormalize(W, H, p::Real=2) = colnormalize!(float(copy(W)), float(copy(H)), p)
 
@@ -109,7 +113,9 @@ Arguments:
 
 -`queuepenalty`: The same as in `nmfmerge`. Default: [`ssdpenalty`](@ref) (`f(E, h1sq, h2sq) = E`).
 
-- `W::AbstractArray`: The basis matrix with normalized columns.
+- `W::AbstractArray`: The basis matrix with unit 2-norm columns (e.g. from
+  [`colnormalize`](@ref) with the default `p=2`). Columns that are not 2-normalized
+  throw an `ArgumentError`.
 
 - `H::AbstractArray`: The coefficient matrix.
 
@@ -148,7 +154,7 @@ function merge_pq(queuepenalty, W::AbstractArray, H::AbstractArray;
     end
     for (id, w) in enumerate(W)
         wnorm = norm(w)
-        (abs(wnorm-1)<1e-12 || iszero(wnorm)) || throw(ArgumentError("W columns must be normalized, $(id)-th column norm = $(wnorm)"))
+        (abs(wnorm-1)<1e-12 || iszero(wnorm)) || throw(ArgumentError("W columns must have unit 2-norm; $(id)-th column 2-norm = $(wnorm). Use `colnormalize` with the default `p=2`."))
     end
     Nt = length(W)
     Nt >= 2 || throw(ArgumentError("Cannot do 2 to 1 merge: Matrix size smaller than 2"))

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -286,6 +286,15 @@ end
     end
 end
 
+@testset "merge_pq requires unit 2-norm columns" begin
+    # Columns normalized in a norm other than 2 are rejected, and the message
+    # points at the 2-norm requirement.
+    W = rand(6, 4)
+    H = rand(4, 9)
+    W1, H1 = colnormalize(W, H, 1)   # unit 1-norm, not unit 2-norm
+    @test_throws "unit 2-norm" merge_pq(W1, H1; nstop=2)
+end
+
 @testset "errstop stopping criterion" begin
     Wn, Hn = colnormalize(float.(W_GT), float.(H_GT))
     ncols = size(Wn, 2)


### PR DESCRIPTION
`colnormalize` accepts any norm order p, but `merge_pq`'s math assumes
unit 2-norm columns. Reword `merge_pq`'s validation error to name the
2-norm and point at colnormalize's default `p=2`, and document the
requirement in the `colnormalize` and `merge_pq` docstrings. Add a test
covering the rejection.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
