### PR TITLE
Use reduce(hcat) in merge_replay to match merge_pq

### DIFF
--- a/src/NMFMerge.jl
+++ b/src/NMFMerge.jl
@@ -271,7 +271,7 @@ function merge_replay(W::AbstractArray, H::AbstractArray, mergeseq::AbstractArra
         id0, id1 = mergeids
         W, H, _, _ = mergecol2to1!(W, H, id0, id1)
     end
-    Wmtx, Hmtx = hcat(filter(!isempty, W)...), hcat(filter(!isempty, H)...)'
+    Wmtx, Hmtx = reduce(hcat, filter(!isempty, W)), reduce(hcat, filter(!isempty, H))'
     return Wmtx, Matrix(Hmtx)
 end
 


### PR DESCRIPTION
`merge_replay` assembled its result by splatting into `hcat`, while
`merge_pq` uses `reduce(hcat, ...)`. Splatting a column vector into
`hcat` is the less robust form for many components; align `merge_replay`
with `merge_pq`. Output is unchanged.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
