### PR TITLE
Accept any integer pair for nmfmerge ncomponents

### DIFF
--- a/src/NMFMerge.jl
+++ b/src/NMFMerge.jl
@@ -71,9 +71,10 @@ function nmfmerge(queuepenalty, X, ncomponents::Pair{Int,Int}; tol_final=1e-4, t
     result_renmf = nnmf(X, n2; kwargs..., init=:custom, tol=tol_final, W0=Wmerge, H0=Hmerge)
     return result_renmf
 end
+nmfmerge(queuepenalty, X, ncomponents::Pair{<:Integer,<:Integer}; kwargs...) = nmfmerge(queuepenalty, X, Int(ncomponents.first) => Int(ncomponents.second); kwargs...)
 nmfmerge(queuepenalty, X, ncomponents::Integer; kwargs...) = nmfmerge(queuepenalty, X, ncomponents+max(1, round(Int, 0.2*ncomponents)) => Int(ncomponents); kwargs...)
-nmfmerge(X, ncomponents::Pair{Int,Int}; kwargs...) = nmfmerge(ssdpenalty, X, ncomponents; kwargs...)
-nmfmerge(X, ncomponents::Integer; kwargs...) = nmfmerge(ssdpenalty, X, ncomponents::Integer; kwargs...)
+nmfmerge(X, ncomponents::Pair{<:Integer,<:Integer}; kwargs...) = nmfmerge(ssdpenalty, X, ncomponents; kwargs...)
+nmfmerge(X, ncomponents::Integer; kwargs...) = nmfmerge(ssdpenalty, X, ncomponents; kwargs...)
 
 function colnormalize!(W, H, p::Real=2)
     nonzerocolids = Int[]

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -84,6 +84,17 @@ H_GT = [6 10 8 2 0 1 2 10;
     @test sum(abs2, result_1.H - result_2.H) <= 1e-12*sum(abs2, result_1.H)
 end
 
+@testset "ncomponents accepts any integer pair" begin
+    X = rand(30, 20)
+    ref = nmfmerge(X, 12 => 10; alg=:cd)
+    for nc in (Int32(12) => Int32(10), 12 => Int32(10), Int32(12) => 10)
+        res = nmfmerge(X, nc; alg=:cd)
+        @test size(res.W, 2) == 10
+        @test res.W ≈ ref.W
+        @test res.H ≈ ref.H
+    end
+end
+
 @testset "merge coefficients" begin
     for i in 1:3, j in i+1:4
         W = W_GT[:, [i,j]]


### PR DESCRIPTION
nmfmerge's Pair methods were restricted to Pair{Int,Int}, so Pair{Int32,Int32}
and mixed integer pairs hit a MethodError. Add a widening method that coerces
any Pair{<:Integer,<:Integer} to Int => Int and delegates to the existing
implementation, and widen the no-penalty Pair method likewise.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
