### PR TITLE
Support Float32 inputs in merge_pq

### DIFF
--- a/src/NMFMerge.jl
+++ b/src/NMFMerge.jl
@@ -145,8 +145,13 @@ down (`nstop == 1`) and locate a "knee" at which to stop, then replay the
 corresponding prefix of `mergeseq` with [`merge_replay`](@ref).
 """
 function merge_pq(queuepenalty, W::AbstractArray, H::AbstractArray;
-                  nstop::Integer=1, errstop=typemax(promote_type(eltype(W), eltype(H))))
-    mrgseq = Tuple{Int, Int, Float64}[]
+                  nstop::Integer=1, errstop=typemax(float(promote_type(eltype(W), eltype(H)))))
+    # Merge errors are floating-point combinations of the W and H entries.
+    T = float(promote_type(eltype(W), eltype(H)))
+    # Tolerance for the unit-2-norm check, scaled to the precision of W so that
+    # e.g. Float32-normalized columns (norm error ~ eps(Float32)) are accepted.
+    normtol = sqrt(eps(float(real(eltype(W)))))
+    mrgseq = Tuple{Int, Int, T}[]
     W = let W = W    # julia #15276
         [W[:, j] for j in axes(W, 2)]
     end
@@ -155,7 +160,7 @@ function merge_pq(queuepenalty, W::AbstractArray, H::AbstractArray;
     end
     for (id, w) in enumerate(W)
         wnorm = norm(w)
-        (abs(wnorm-1)<1e-12 || iszero(wnorm)) || throw(ArgumentError("W columns must have unit 2-norm; $(id)-th column 2-norm = $(wnorm). Use `colnormalize` with the default `p=2`."))
+        (abs(wnorm-1)<normtol || iszero(wnorm)) || throw(ArgumentError("W columns must have unit 2-norm; $(id)-th column 2-norm = $(wnorm). Use `colnormalize` with the default `p=2`."))
     end
     Nt = length(W)
     Nt >= 2 || throw(ArgumentError("Cannot do 2 to 1 merge: Matrix size smaller than 2"))

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -306,6 +306,17 @@ end
     @test_throws "unit 2-norm" merge_pq(W1, H1; nstop=2)
 end
 
+@testset "merge_pq error eltype follows factors" begin
+    W = rand(6, 4); H = rand(4, 9)
+    for Tf in (Float64, Float32)
+        Wn, Hn = colnormalize(Tf.(W), Tf.(H))
+        @test eltype(Wn) === Tf
+        Wm, Hm, seq = merge_pq(Wn, Hn; nstop=1)
+        @test eltype(Wm) === Tf
+        @test eltype(seq) === Tuple{Int,Int,Tf}
+    end
+end
+
 @testset "errstop stopping criterion" begin
     Wn, Hn = colnormalize(float.(W_GT), float.(H_GT))
     ncols = size(Wn, 2)


### PR DESCRIPTION
Two coupled fixes for non-Float64 factors:

- The unit-2-norm check used a hardcoded 1e-12 tolerance, which is below
  eps(Float32). Float32-normalized columns have norm error ~1e-7 and were
  rejected, making merge_pq and nmfmerge unusable for Float32 data. Scale
  the tolerance to the input precision with sqrt(eps(eltype(W))); this only
  loosens the Float64 check.
- The merge schedule's error field was hardcoded to Float64. Derive its
  element type from the factor eltypes so Float32 inputs yield Float32
  merge errors matching the returned factors.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
