### PR TITLE
Support offset feature/sample axes in merge functions

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "NMFMerge"
 uuid = "9cc52eda-dfaf-4e21-aae3-9f26bed153a3"
-authors = ["youdongguo <1010705897@qq.com> and contributors"]
 version = "1.1.1"
+authors = ["youdongguo <1010705897@qq.com> and contributors"]
 
 [deps]
 DataStructures = "864edb3b-99cc-5e75-8d2d-829cb0a9cfe8"
@@ -18,6 +18,7 @@ ForwardDiff = "0.10"
 GsvdInitialization = "2"
 LinearAlgebra = "1"
 NMF = "1"
+OffsetArrays = "1"
 TSVD = "0.4"
 Test = "1"
 julia = "1.10"
@@ -27,7 +28,8 @@ Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"
 ExplicitImports = "7d51a73a-1435-4ff3-83d9-f097790105c7"
 ForwardDiff = "f6369f11-7733-5829-9624-2563aa707210"
 NMF = "6ef6ca0d-6ad7-5ff6-b225-e928bfa0a386"
+OffsetArrays = "6fe1bfb0-de20-5000-8ca7-80f57d26f881"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["Aqua", "ExplicitImports", "ForwardDiff", "NMF", "Test"]
+test = ["Aqua", "ExplicitImports", "ForwardDiff", "NMF", "OffsetArrays", "Test"]

--- a/src/NMFMerge.jl
+++ b/src/NMFMerge.jl
@@ -77,6 +77,7 @@ nmfmerge(X, ncomponents::Pair{<:Integer,<:Integer}; kwargs...) = nmfmerge(ssdpen
 nmfmerge(X, ncomponents::Integer; kwargs...) = nmfmerge(ssdpenalty, X, ncomponents; kwargs...)
 
 function colnormalize!(W, H, p::Real=2)
+    check_component_axis(W, H)
     nonzerocolids = Int[]
     for (j, w) in pairs(eachcol(W))
         normw = norm(w, p)
@@ -100,6 +101,9 @@ accepted (e.g. `1`, `2`, `Inf`).
 [`merge_pq`](@ref) and [`nmfmerge`](@ref) require unit *2-norm* columns, so use
 the default `p=2` when preparing input for the merge. Other orders are available
 for unrelated normalization needs.
+
+The component axis (columns of `W`, rows of `H`) must be one-based; the feature
+axis (rows of `W`) and sample axis (columns of `H`) may have any axes.
 
 """
 colnormalize(W, H, p::Real=2) = colnormalize!(float(copy(W)), float(copy(H)), p)
@@ -131,6 +135,11 @@ Keyword arguments:
 
 The defaults on these keywords allow merging all the way down to a single component.
 
+The component axis (columns of `W`, rows of `H`) is enumeration and must be
+one-based. The feature axis (rows of `W`) and sample axis (columns of `H`) may
+have any axes and are carried through to the output; the merged component axis
+is one-based.
+
 Outputs:
 
 `Wmerge` and `Hmerge` are the merged results; the number of surviving components
@@ -146,51 +155,63 @@ corresponding prefix of `mergeseq` with [`merge_replay`](@ref).
 """
 function merge_pq(queuepenalty, W::AbstractArray, H::AbstractArray;
                   nstop::Integer=1, errstop=typemax(float(promote_type(eltype(W), eltype(H)))))
+    check_component_axis(W, H)
     # Merge errors are floating-point combinations of the W and H entries.
     T = float(promote_type(eltype(W), eltype(H)))
     # Tolerance for the unit-2-norm check, scaled to the precision of W so that
     # e.g. Float32-normalized columns (norm error ~ eps(Float32)) are accepted.
     normtol = sqrt(eps(float(real(eltype(W)))))
     mrgseq = Tuple{Int, Int, T}[]
-    W = let W = W    # julia #15276
-        [W[:, j] for j in axes(W, 2)]
-    end
-    H = let H = H
-        [H[i, :] for i in axes(H, 1)]
-    end
-    for (id, w) in enumerate(W)
+    # One-based stack of component columns (of `W`) and rows (of `H`); each merge
+    # appends a new component. The feature axis (rows of `W`) and sample axis
+    # (columns of `H`) ride along on these vectors and reappear in the output.
+    # The component axis is one-based (checked above), so `1:size` enumerates it.
+    Wcols = [W[:, j] for j in 1:size(W, 2)]
+    Hrows = [H[i, :] for i in 1:size(H, 1)]
+    for (id, w) in enumerate(Wcols)
         wnorm = norm(w)
         (abs(wnorm-1)<normtol || iszero(wnorm)) || throw(ArgumentError("W columns must have unit 2-norm; $(id)-th column 2-norm = $(wnorm). Use `colnormalize` with the default `p=2`."))
     end
-    Nt = length(W)
+    Nt = length(Wcols)
     Nt >= 2 || throw(ArgumentError("Cannot do 2 to 1 merge: Matrix size smaller than 2"))
     Nt >= nstop || throw(ArgumentError("Final solution more than original size"))
+    # Merging marks components dead rather than deleting them, keeping ids stable.
+    alive = trues(Nt)
     pq = PriorityQueue{Tuple{Int,Int},Float64}()
-    for id0 in length(W):-1:2
-        pq = pqupdate2to1!(queuepenalty, pq, W, H, id0, 1:id0-1)
+    for id0 in Nt:-1:2
+        pq = pqupdate2to1!(queuepenalty, pq, Wcols, Hrows, alive, id0, 1:id0-1)
     end
     m = Nt
     while m > nstop && !isempty(pq)
         (id0, id1), penalty = first(pq)
-        if isempty(W[id0])||isempty(W[id1])
+        if !alive[id0] || !alive[id1]
             popfirst!(pq)
             continue
         end
         penalty > errstop && break
         popfirst!(pq)
-        W, H, id01, loss = mergecol2to1!(W, H, id0, id1)
+        id01, loss = mergecol2to1!(Wcols, Hrows, alive, id0, id1)
         push!(mrgseq, (id0, id1, loss))
-        pqupdate2to1!(queuepenalty, pq, W, H, id01, 1:id01-1);
+        pqupdate2to1!(queuepenalty, pq, Wcols, Hrows, alive, id01, 1:id01-1)
         m -= 1
     end
-    Wmtx, Hmtx = reduce(hcat, filter(!isempty, W)), reduce(hcat, filter(!isempty, H))'
-    return Wmtx, Matrix(Hmtx), mrgseq
+    return stack(Wcols[alive]), stack(Hrows[alive]; dims=1), mrgseq
 end
 merge_pq(W::AbstractArray, H::AbstractArray; kwargs...) = merge_pq(ssdpenalty, W, H; kwargs...)
 
-function pqupdate2to1!(queuepenalty::Function, pq, S::AbstractVector, T::AbstractVector, id01::Integer, overlapids::AbstractRange{To}) where To
+# The component axis (columns of `W`, rows of `H`) is plain enumeration, so it
+# must be shared and one-based; the feature axis (rows of `W`) and sample axis
+# (columns of `H`) may carry any axes.
+function check_component_axis(W, H)
+    axes(W, 2) == axes(H, 1) || throw(DimensionMismatch("W has $(size(W, 2)) components but H has $(size(H, 1))"))
+    isone(first(axes(W, 2))) || throw(ArgumentError("the component axis (columns of `W`, rows of `H`) must be one-based"))
+    return nothing
+end
+
+function pqupdate2to1!(queuepenalty::Function, pq, S::AbstractVector, T::AbstractVector, alive::AbstractVector{Bool}, id01::Integer, overlapids::AbstractRange{To}) where To
+    alive[id01] || return pq
     for id in overlapids
-        if !isempty(S[id]) && !isempty(S[id01])
+        if alive[id]
             _, loss, _, t1sq, t2sq = solve_remix(S, T, id, id01)
             push!(pq, (id, id01) => queuepenalty(loss, t1sq, t2sq))
         end
@@ -234,13 +255,13 @@ function build_tr_det(W::AbstractVector, H::AbstractVector, id1::Integer, id2::I
     return τ, δ, c, h1h1, h1h2, h2h2
 end
 
-function mergecol2to1!(S::AbstractVector, T::AbstractVector, id0::Integer, id1::Integer)
+function mergecol2to1!(S::AbstractVector, T::AbstractVector, alive::AbstractVector{Bool}, id0::Integer, id1::Integer)
     S01, T01, loss = mergepair(S, T, id0, id1)
-    S[id0] = S[id1] = T[id0] = T[id1] = eltype(S[1])[]
-    id01 = length(S)+1
+    alive[id0] = alive[id1] = false
     push!(S, S01)
     push!(T, T01)
-    return S, T, id01, loss
+    push!(alive, true)
+    return length(S), loss
 end
 
 function mergepair(S::AbstractVector, T::AbstractVector, id1::Integer, id2::Integer)
@@ -249,12 +270,9 @@ function mergepair(S::AbstractVector, T::AbstractVector, id1::Integer, id2::Inte
     return S12, T12, loss
 end
 
-function remix_enact(S::AbstractVector{TS}, T::AbstractVector, id1::Integer, id2::Integer, c::AbstractFloat, w::Tuple{Tw, Tw}) where {Tw, TS}
-    S12 = zeros(eltype(TS), length(S[id1]))
-    S12 += w[1]*S[id1]
-    S12 += w[2]*S[id2]
-    T1, T2 = (w[1]+w[2]*c)*T[id1], (w[1]*c+w[2])*T[id2]
-    T12 = T1+T2
+function remix_enact(S::AbstractVector, T::AbstractVector, id1::Integer, id2::Integer, c, w)
+    S12 = w[1] .* S[id1] .+ w[2] .* S[id2]
+    T12 = (w[1]+w[2]*c) .* T[id1] .+ (w[1]*c+w[2]) .* T[id2]
     return S12, T12
 end
 
@@ -269,16 +287,21 @@ further fields are ignored, so the `(id1, id2, err)` triples returned by
 [`merge_pq`](@ref) can be replayed directly. Replaying a prefix of a `merge_pq`
 schedule reproduces the factors `merge_pq` would have returned had it stopped at
 the corresponding number of components.
+
+As in [`merge_pq`](@ref), the component axis must be one-based while the feature
+and sample axes are carried through to the output.
 """
 function merge_replay(W::AbstractArray, H::AbstractArray, mergeseq::AbstractArray)
-    W = [W[:, j] for j in axes(W, 2)]
-    H = [H[i, :] for i in axes(H, 1)]
+    check_component_axis(W, H)
+    # One-based component stack carrying the feature/sample axes (see `merge_pq`).
+    Wcols = [W[:, j] for j in 1:size(W, 2)]
+    Hrows = [H[i, :] for i in 1:size(H, 1)]
+    alive = trues(length(Wcols))
     for mergeids in mergeseq
         id0, id1 = mergeids
-        W, H, _, _ = mergecol2to1!(W, H, id0, id1)
+        mergecol2to1!(Wcols, Hrows, alive, id0, id1)
     end
-    Wmtx, Hmtx = reduce(hcat, filter(!isempty, W)), reduce(hcat, filter(!isempty, H))'
-    return Wmtx, Matrix(Hmtx)
+    return stack(Wcols[alive]), stack(Hrows[alive]; dims=1)
 end
 
 """

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -2,6 +2,7 @@ using NMFMerge, NMF, LinearAlgebra, DataStructures, ForwardDiff
 using Test
 using Aqua
 using ExplicitImports
+using OffsetArrays
 
 @testset "Aqua" begin
     Aqua.test_all(NMFMerge)
@@ -309,9 +310,9 @@ end
 @testset "merge_pq error eltype follows factors" begin
     W = rand(6, 4); H = rand(4, 9)
     for Tf in (Float64, Float32)
-        Wn, Hn = colnormalize(Tf.(W), Tf.(H))
+        Wn, Hn = @inferred colnormalize(Tf.(W), Tf.(H))
         @test eltype(Wn) === Tf
-        Wm, Hm, seq = merge_pq(Wn, Hn; nstop=1)
+        Wm, Hm, seq = @inferred merge_pq(Wn, Hn; nstop=1)
         @test eltype(Wm) === Tf
         @test eltype(seq) === Tuple{Int,Int,Tf}
     end
@@ -345,4 +346,68 @@ end
     Wd, _, seqd = merge_pq(Wn, Hn; nstop=1)
     @test length(seqd) == length(schedule)
     @test size(Wd, 2) == 1
+end
+
+@testset "generic axes" begin
+    Wn, Hn = colnormalize(float.(W_GT), float.(H_GT))
+
+    # The component axis (columns of `W`, rows of `H`) is enumeration and must be
+    # one-based, but the feature axis (rows of `W`) and sample axis (columns of
+    # `H`) may be offset and are carried through to the output. Offset only those
+    # two; the merged component axis comes out one-based.
+    Wo = OffsetArray(collect(Wn), -2, 0)    # feature shift -2, component one-based
+    Ho = OffsetArray(collect(Hn), 0, -1)    # component one-based, sample shift -1
+    vals(A) = collect(A)[:]                 # values in column-major order, axes discarded
+
+    @testset "colnormalize" begin
+        rW, rH = @inferred colnormalize(Wn, Hn)
+        oW, oH = @inferred colnormalize(Wo, Ho)
+        @test vals(oW) == vals(rW) && vals(oH) == vals(rH)
+        @test axes(oW, 1) == axes(Wo, 1)        # feature axis preserved
+        @test axes(oH, 2) == axes(Ho, 2)        # sample axis preserved
+        vW, vH = @inferred colnormalize(view(Wn, :, :), view(Hn, :, :))
+        @test vW == rW && vH == rH
+    end
+
+    @testset "merge_pq" begin
+        rW, rH, rseq = @inferred merge_pq(Wn, Hn; nstop=2)
+        oW, oH, oseq = @inferred merge_pq(Wo, Ho; nstop=2)
+        @test vals(oW) == vals(rW) && vals(oH) == vals(rH) && oseq == rseq
+        @test axes(oW, 1) == axes(Wo, 1)        # feature axis preserved
+        @test axes(oW, 2) == 1:2                # components re-enumerated, one-based
+        @test axes(oH, 2) == axes(Ho, 2)        # sample axis preserved
+        vW, vH, vseq = @inferred merge_pq(view(Wn, :, :), view(Hn, :, :); nstop=2)
+        @test vW == rW && vH == rH && vseq == rseq
+    end
+
+    @testset "merge_replay" begin
+        _, _, seq = merge_pq(Wn, Hn; nstop=1)
+        rW, rH = @inferred merge_replay(Wn, Hn, seq)
+        oW, oH = @inferred merge_replay(Wo, Ho, seq)
+        @test vals(oW) == vals(rW) && vals(oH) == vals(rH)
+        @test axes(oW, 1) == axes(Wo, 1)        # feature axis preserved
+        @test axes(oH, 2) == axes(Ho, 2)        # sample axis preserved
+        vW, vH = @inferred merge_replay(view(Wn, :, :), view(Hn, :, :), seq)
+        @test vW == rW && vH == rH
+    end
+
+    @testset "mismatched component dimension" begin
+        @test_throws DimensionMismatch colnormalize(rand(6, 4), rand(3, 9))
+        @test_throws DimensionMismatch merge_pq(rand(6, 4), rand(3, 9); nstop=2)
+        @test_throws DimensionMismatch merge_replay(rand(6, 4), rand(3, 9), [(1, 2)])
+    end
+
+    @testset "non-one-based component axis rejected" begin
+        Wc = OffsetArray(collect(Wn), 0, -3)    # component axis shifted off one
+        Hc = OffsetArray(collect(Hn), -3, 0)
+        @test_throws "one-based" colnormalize(Wc, Hc)
+        @test_throws "one-based" merge_pq(Wc, Hc; nstop=2)
+        @test_throws "one-based" merge_replay(Wc, Hc, [(1, 2)])
+    end
+
+    @testset "nmfmerge rejects offset input" begin
+        # `nmfmerge` delegates to TSVD/NMF, which require one-based indexing.
+        X = OffsetArray(rand(20, 15), -2, -3)
+        @test_throws "offset arrays are not supported" nmfmerge(X, 4; alg=:cd)
+    end
 end


### PR DESCRIPTION
`colnormalize`, `merge_pq`, and `merge_replay` now accept inputs with
offset feature (rows of W) and sample (columns of H) axes and carry those
axes through to their outputs. The component axis (columns of W, rows of H)
is plain enumeration, so it must be one-based and is checked by
`check_component_axis`, which throws on a shared/one-based violation.

The merge core is axis-generic: components live in a one-based stack with an
`alive` mask (rather than empty-vector tombstones), `remix_enact` combines
columns by broadcasting, and results are assembled with `stack`, which
preserves the data axes. This keeps the column stack a concrete element type
so the outputs are type-stable for both plain and offset inputs.

Add OffsetArrays as a test dependency and a "generic axes" test set that
wraps inputs in OffsetArrays and views, asserts value- and axis-correctness,
and uses `@inferred` to lock the output types.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
