### PR TITLE
Document the public API with tested examples

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -13,6 +13,7 @@ TSVD = "9449cd9e-2762-5aa3-a617-5413e99d722e"
 [compat]
 Aqua = "0.8"
 DataStructures = "0.19"
+Documenter = "1"
 ExplicitImports = "1.15"
 ForwardDiff = "0.10"
 GsvdInitialization = "2"
@@ -25,6 +26,7 @@ julia = "1.10"
 
 [extras]
 Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"
+Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
 ExplicitImports = "7d51a73a-1435-4ff3-83d9-f097790105c7"
 ForwardDiff = "f6369f11-7733-5829-9624-2563aa707210"
 NMF = "6ef6ca0d-6ad7-5ff6-b225-e928bfa0a386"
@@ -32,4 +34,4 @@ OffsetArrays = "6fe1bfb0-de20-5000-8ca7-80f57d26f881"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["Aqua", "ExplicitImports", "ForwardDiff", "NMF", "OffsetArrays", "Test"]
+test = ["Aqua", "Documenter", "ExplicitImports", "ForwardDiff", "NMF", "OffsetArrays", "Test"]

--- a/src/NMFMerge.jl
+++ b/src/NMFMerge.jl
@@ -1,3 +1,19 @@
+"""
+    NMFMerge
+
+Improve nonnegative matrix factorization (NMF) by over-factorizing and then
+merging components in pairs. Factorizing `X ≈ W * H` with more components than
+ultimately desired and merging the closest pairs tends to reach better and more
+reproducible optima than factorizing directly into the target number of
+components (Guo & Holy, IEEE Trans. Signal Process. 2025,
+doi:10.1109/TSP.2025.3585893).
+
+The high-level entry point is [`nmfmerge`](@ref), which runs the whole pipeline.
+The building blocks are also exported: [`colnormalize`](@ref) to unit-normalize
+the columns of `W`, [`merge_pq`](@ref) to merge a factorization down to a chosen
+number of components while recording the merge sequence, and
+[`merge_replay`](@ref) to replay a prefix of that sequence.
+"""
 module NMFMerge
 
 using LinearAlgebra: LinearAlgebra, norm
@@ -20,32 +36,55 @@ end
 """
     result = nmfmerge([queuepenalty], X, ncomponents; tol_final=1e-4, tol_intermediate=sqrt(tol_final), W0=nothing, H0=nothing, kwargs...)
 
-Performs "NMF-Merge" on data matrix `X`.
+Perform "NMF-Merge" on data matrix `X`: factorize `X` with more components than
+ultimately desired and then iteratively merge components in pairs, which tends to
+reach better and more reproducible optima than a direct factorization (Guo &
+Holy, IEEE Trans. Signal Process. 2025, doi:10.1109/TSP.2025.3585893).
+
+Return an `NMF.Result` whose `W` and `H` fields hold the final factorization
+`X ≈ W * H` with the requested final number of components.
 
 Arguments:
 
--`queuepenalty`: a function of the form `f(E, h1sq, h2sq)` that computes the penalty for merging two components, where `E` is the the merge error described in the paper, default: [`ssdpenalty`](@ref) (`f(E, h1sq, h2sq) = E`). h1sq and h2sq are the squared norms of the corresponding rows in H.
+- `queuepenalty`: a function of the form `f(E, h1sq, h2sq)` that computes the
+  penalty for merging two components, where `E` is the merge error (the increase
+  in reconstruction error) and `h1sq`, `h2sq` are the squared norms of the
+  corresponding rows of `H`. Default: [`ssdpenalty`](@ref)
+  (`f(E, h1sq, h2sq) = E`), which merges purely in order of increasing
+  reconstruction error.
 
-- `X::AbstractMatrix`: the data matrix to be factorized
+- `X::AbstractMatrix`: the data matrix to be factorized.
 
-- `ncomponents::Pair{Int,Int}`: in the form of `n1 => n2`, merging from `n1` components to `n2`components,
-  where `n1` is the number of components for overcomplete NMF, and `n2` is the number of components for the final NMF.
-  We require `n1 >= n2`.
-
-Alternatively, `ncomponents` can be an integer denoting the final number of components. In this case, `nmfmerge`
-defaults to an approximate 20% component excess before merging.
-
+- `ncomponents::Pair{<:Integer,<:Integer}`: in the form `n1 => n2`, merging from
+  `n1` components to `n2`, where `n1` is the number of components for the
+  overcomplete NMF and `n2` is the number of components for the final NMF. We
+  require `n1 >= n2`. Alternatively, `ncomponents` can be an integer denoting the
+  final number of components; in that case `nmfmerge` defaults to an approximate
+  20% component excess before merging.
 
 Keyword arguments:
 
-- `tol_final`: The tolerance of final NMF
+- `tol_final`: the tolerance of the final NMF.
 
-- `tol_intermediate`: The tolerence of initial and overcomplete NMF
+- `tol_intermediate`: the tolerance of the initial and overcomplete NMF.
 
-`W0`, `H0`: initialization for the initial NMF. If at least one of `W0` and `H0` is `nothing`, NNDSVD is used for initialization.
+- `W0`, `H0`: initialization for the initial NMF. If at least one of `W0` and
+  `H0` is `nothing`, NNDSVD is used for initialization.
 
+Other keyword arguments are passed to `NMF.nnmf`.
 
-Other keywords arguments are passed to `NMF.nnmf`.
+# Examples
+
+```julia
+julia> X = abs.(randn(100, 50));        # nonnegative data
+
+julia> result = nmfmerge(X, 5);         # merge down to 5 components
+
+julia> size(result.W), size(result.H)
+((100, 5), (5, 50))
+
+julia> result = nmfmerge(X, 8 => 5);    # 8 overcomplete components, merge to 5
+```
 """
 function nmfmerge(queuepenalty, X, ncomponents::Pair{Int,Int}; tol_final=1e-4, tol_intermediate=sqrt(tol_final), W0=nothing, H0=nothing, kwargs...)
     n1, n2 = ncomponents
@@ -94,9 +133,13 @@ end
 """
     Wnormalized, Hnormalized = colnormalize(W, H, p=2)
 
-Normalize the factorization so that each column satisfies `||W[:, i]||_p ≈ 1`.
-`p` is the norm order passed to `LinearAlgebra.norm`, so any real order is
-accepted (e.g. `1`, `2`, `Inf`).
+Normalize the factorization so that each retained column satisfies
+`norm(W[:, i], p) ≈ 1`, rescaling the matching row of `H` by the same factor so
+that `W * H` is unchanged. `p` is the norm order passed to `LinearAlgebra.norm`,
+so any real order is accepted (e.g. `1`, `2`, `Inf`).
+
+Columns of `W` with zero norm carry no information and are dropped together with
+their `H` rows, so the returned factors may have fewer components than the input.
 
 [`merge_pq`](@ref) and [`nmfmerge`](@ref) require unit *2-norm* columns, so use
 the default `p=2` when preparing input for the merge. Other orders are available
@@ -105,6 +148,24 @@ for unrelated normalization needs.
 The component axis (columns of `W`, rows of `H`) must be one-based; the feature
 axis (rows of `W`) and sample axis (columns of `H`) may have any axes.
 
+# Examples
+
+```jldoctest
+julia> W = [3.0 0.0; 4.0 0.0];   # second column has zero norm
+
+julia> H = [1.0 2.0; 3.0 4.0];
+
+julia> Wn, Hn = colnormalize(W, H);
+
+julia> Wn
+2×1 Matrix{Float64}:
+ 0.6
+ 0.8
+
+julia> Hn
+1×2 Matrix{Float64}:
+ 5.0  10.0
+```
 """
 colnormalize(W, H, p::Real=2) = colnormalize!(float(copy(W)), float(copy(H)), p)
 
@@ -135,10 +196,10 @@ Keyword arguments:
 
 The defaults on these keywords allow merging all the way down to a single component.
 
-The component axis (columns of `W`, rows of `H`) is enumeration and must be
-one-based. The feature axis (rows of `W`) and sample axis (columns of `H`) may
-have any axes and are carried through to the output; the merged component axis
-is one-based.
+The component axis (columns of `W`, rows of `H`) is a plain enumeration and must
+be one-based. The feature axis (rows of `W`) and sample axis (columns of `H`)
+may have any axes and are carried through to the output; the merged component
+axis is one-based.
 
 Outputs:
 
@@ -152,6 +213,25 @@ Ids larger than the number of columns in `W` refer to components produced by
 earlier merges. The accumulating `err` values let a caller merge all the way
 down (`nstop == 1`) and locate a "knee" at which to stop, then replay the
 corresponding prefix of `mergeseq` with [`merge_replay`](@ref).
+
+# Examples
+
+```jldoctest
+julia> W = [1.0 0.0 0.0; 0.0 1.0 1.0];   # columns 2 and 3 are identical
+
+julia> H = [2.0 5.0; 3.0 7.0; 4.0 11.0];
+
+julia> Wmerge, Hmerge, mergeseq = merge_pq(W, H; nstop=2);
+
+julia> Hmerge
+2×2 Matrix{Float64}:
+ 2.0   5.0
+ 7.0  18.0
+
+julia> mergeseq
+1-element Vector{Tuple{Int64, Int64, Float64}}:
+ (2, 3, 0.0)
+```
 """
 function merge_pq(queuepenalty, W::AbstractArray, H::AbstractArray;
                   nstop::Integer=1, errstop=typemax(float(promote_type(eltype(W), eltype(H)))))
@@ -290,6 +370,17 @@ the corresponding number of components.
 
 As in [`merge_pq`](@ref), the component axis must be one-based while the feature
 and sample axes are carried through to the output.
+
+# Examples
+
+```jldoctest
+julia> W = [1.0 0.0 0.0; 0.0 1.0 1.0];
+
+julia> H = [2.0 5.0; 3.0 7.0; 4.0 11.0];
+
+julia> merge_replay(W, H, [(2, 3)])
+([1.0 0.0; 0.0 1.0], [2.0 5.0; 7.0 18.0])
+```
 """
 function merge_replay(W::AbstractArray, H::AbstractArray, mergeseq::AbstractArray)
     check_component_axis(W, H)
@@ -308,11 +399,18 @@ end
     ssdpenalty(E, h1sq, h2sq)
 
 The default merge penalty: the merge error `E` itself, ignoring the squared
-norms `h1sq`, `h2sq` of the two `H` rows. With this penalty `merge_pq`
-and `nmfmerge` merge purely in order of increasing reconstruction error.
+norms `h1sq`, `h2sq` of the two `H` rows. With this penalty [`merge_pq`](@ref)
+and [`nmfmerge`](@ref) merge purely in order of increasing reconstruction error.
 
 Pass a custom `f(E, h1sq, h2sq)` as the leading argument to those functions to
 weight merges differently.
+
+# Examples
+
+```jldoctest
+julia> NMFMerge.ssdpenalty(1.5, 2.0, 3.0)
+1.5
+```
 """
 ssdpenalty(E, h1sq, h2sq) = E
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -3,6 +3,13 @@ using Test
 using Aqua
 using ExplicitImports
 using OffsetArrays
+using Documenter
+
+DocMeta.setdocmeta!(NMFMerge, :DocTestSetup, :(using NMFMerge); recursive=true)
+
+@testset "Doctests" begin
+    doctest(NMFMerge; manual=false)
+end
 
 @testset "Aqua" begin
     Aqua.test_all(NMFMerge)


### PR DESCRIPTION
Add a module docstring and bring the exported functions' docstrings up
to convention: imperative mood, accurate signatures and return values,
and the colnormalize zero-column-dropping contract. Cite the NMF-Merge
publication (doi:10.1109/TSP.2025.3585893) in place of an uncited
reference.

Add jldoctest examples and exercise them via Documenter's doctest in
the test suite.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
