### PR TITLE
Clamp eigenvalue discriminant in solve_remix

### DIFF
--- a/src/NMFMerge.jl
+++ b/src/NMFMerge.jl
@@ -312,7 +312,10 @@ function solve_remix(S::AbstractVector, T::AbstractVector, id1::Integer, id2::In
         iszero(sum(abs2, S[id1])) && return c, zero(h1h1), (zero(c), one(c)), h1h1, h2h2
         iszero(sum(abs2, S[id2])) && return c, zero(h2h2), (one(c), zero(c)), h1h1, h2h2
     end
-    b = sqrt(τ^2/4-δ)
+    # τ/2 ± b are the eigenvalues of a symmetric pencil, so the discriminant
+    # τ^2/4 - δ is nonnegative in exact arithmetic; clamp roundoff that pushes it
+    # slightly below zero (otherwise `sqrt` throws on near-degenerate pairs).
+    b = sqrt(max(zero(δ), τ^2/4-δ))
     λ_max = τ/2+b
     λ_min = δ/λ_max
     den = (h1h2+c*h2h2)*2

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -220,6 +220,27 @@ end
     @test h1h1 == 4.0 && h2h2 == 1.0
 end
 
+@testset "solve_remix discriminant clamp" begin
+    # τ/2 ± sqrt(τ^2/4-δ) are eigenvalues of a symmetric pencil, so the
+    # discriminant is nonnegative in exact arithmetic. Orthonormal W columns
+    # (c=0) and disjoint H rows (h1h2=0) with equal squared norms make it vanish;
+    # roundoff then pushes it slightly negative, and solve_remix must clamp
+    # rather than call sqrt on a negative number.
+    S = [[1.0, 0.0], [0.0, 1.0]]
+    T = [[3.0, 4.0, 0.0, 0.0, 0.0], [0.0, 0.0, 5/3, 10/3, 10/3]]  # ‖T1‖² = ‖T2‖² = 25
+    τ, δ, _, _, _, _ = NMFMerge.build_tr_det(S, T, 1, 2)
+    @test τ^2/4 - δ < 0                       # the negative discriminant this guards against
+    c, λ, u, h1h1, h2h2 = NMFMerge.solve_remix(S, T, 1, 2)
+    @test isfinite(λ) && all(isfinite, u)
+    @test λ ≈ 25                              # degenerate pencil: both eigenvalues equal
+
+    # The same degeneracy reached through the public merge entry point.
+    W = [1.0 0.0; 0.0 1.0; 0.0 0.0; 0.0 0.0; 0.0 0.0]
+    H = [3.0 4.0 0.0 0.0 0.0; 0.0 0.0 5/3 10/3 10/3]
+    Wm, Hm, seq = merge_pq(W, H; nstop=1)
+    @test size(Wm, 2) == 1
+end
+
 @testset "Merge by min err" begin
     # Two cells, one is bright and the other dim. The bright cell is split into two tiles that alternate time points
     S1 = [0.1, 0.5, 0.4, 0.0, 0.0, 0.0]; S1 = S1 / norm(S1);


### PR DESCRIPTION
`solve_remix` forms the eigenvalues of a symmetric 2x2 pencil as τ/2 ± sqrt(τ^2/4 - δ). The discriminant τ^2/4 - δ is nonnegative in exact arithmetic, but for a near-degenerate pair (orthogonal W columns and orthogonal H rows of equal norm) roundoff can drive it slightly below zero, throwing a DomainError from `sqrt`. Clamp it to zero.

The regression test constructs such a pair directly and also drives it through `merge_pq`.